### PR TITLE
Prepare Falcon for coupledGradient() const reference return value.

### DIFF
--- a/include/auxkernels/VariableGradientAux.h
+++ b/include/auxkernels/VariableGradientAux.h
@@ -46,7 +46,7 @@ class VariableGradientAux : public AuxKernel
   protected:
     virtual Real computeValue();
 
-    VariableGradient & _grad_coupled_variable;
+    const VariableGradient & _grad_coupled_variable;
 
     int _i;
 };

--- a/include/materials/PTGeothermal.h
+++ b/include/materials/PTGeothermal.h
@@ -105,8 +105,8 @@ class PTGeothermal : public Material
     const VariableValue & _pres; // pressure
     const VariableValue & _temp; // temperature
 
-    VariableGradient & _grad_pres; // pressure gradient
-    VariableGradient & _grad_temp; // temperature gradient
+    const VariableGradient & _grad_pres; // pressure gradient
+    const VariableGradient & _grad_temp; // temperature gradient
 
     // ===================
     // material properties


### PR DESCRIPTION
This set of changes prepares Falcon to work with an upcoming version of
MOOSE in which coupledGradient() returns a const reference.

Refs idaholab/moose#6327.