### PR TITLE
Change to use of initial eigenstrain for initial stress calculation

### DIFF
--- a/tests/THM_injection/thm_steady.i
+++ b/tests/THM_injection/thm_steady.i
@@ -454,14 +454,19 @@
   [../]
   [./strain]
     type = ComputeIncrementalSmallStrain
+    eigenstrain_names = 'ini_stress'
   [../]
   [./stress]
     type = ComputeMultiPlasticityStress
-    initial_stress = 'kxx_fcn kxy_fcn 0  kxy_fcn kyy_fcn 0  0 0 weight_fcn'
     # the rest of this stuff is irrelevant for this test
     ep_plastic_tolerance = 1E-5
     plastic_models = mc
     debug_fspb = crash
+  [../]
+  [./strain_from_initial_stress]
+    type = ComputeEigenstrainFromInitialStress
+    initial_stress = 'kxx_fcn kxy_fcn 0  kxy_fcn kyy_fcn 0  0 0 weight_fcn'
+    eigenstrain_name = ini_stress
   [../]
   [./density]
     type = GenericConstantMaterial


### PR DESCRIPTION
Changes over an input file to use ComputeEigenstrainFromInitialStress for all initial stress values.
This change is needed for the removal of the initial_stress deprecated parameter in [idaholab/moose #11503](https://github.com/idaholab/moose/pull/11503)

Refs [idaholab/moose #10074](https://github.com/idaholab/moose/issues/10074)