### PR TITLE
Explicitly call dot() in classes which need _u_dot().

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,5 @@ peacock_*.e
 lib
 include/FalconRevision.h
 include/base/FalconRevision.h
+.previous_test_results.json
+build/

--- a/include/base/FalconApp.h
+++ b/include/base/FalconApp.h
@@ -27,9 +27,8 @@ class FalconApp : public MooseApp
 public:
   FalconApp(InputParameters parameters);
 
+  static void registerAll(Factory & factory, ActionFactory & action_factory, Syntax & syntax);
   static void registerApps();
-  static void registerObjects(Factory & factory);
-  static void associateSyntax(Syntax & syntax, ActionFactory & action_factory);
 };
 
 #endif //FALCONAPP_H

--- a/include/kernels/PTEnergyResidual.h
+++ b/include/kernels/PTEnergyResidual.h
@@ -45,6 +45,8 @@ class PTEnergyResidual : public Kernel
     const MaterialProperty<Real> & _tau2;
     const MaterialProperty<RealGradient> & _wdmfx;
     const MaterialProperty<RealGradient> & _evelo;
+    const VariableValue & _u_dot;
+    const VariableValue & _du_dot_du;
 
   private:
 

--- a/include/materials/PTGeothermal.h
+++ b/include/materials/PTGeothermal.h
@@ -161,7 +161,7 @@ class PTGeothermal : public Material
     // ============================
     // stateful material properties
     // ============================
-    MaterialProperty<Real> & _wrho_old; // water density at previous time step
+    const MaterialProperty<Real> & _wrho_old; // water density at previous time step
 
   private:
 

--- a/src/base/FalconApp.C
+++ b/src/base/FalconApp.C
@@ -44,13 +44,22 @@ Routine: FalconApp -- constructor
 FalconApp::FalconApp(InputParameters parameters) :
     MooseApp(parameters)
 {
-  Moose::registerObjects(_factory);
-  ModulesApp::registerObjects(_factory);
-  FalconApp::registerObjects(_factory);
+  FalconApp::registerAll(_factory, _action_factory, _syntax);
+}
 
-  Moose::associateSyntax(_syntax, _action_factory);
-  ModulesApp::associateSyntax(_syntax, _action_factory);
-  FalconApp::associateSyntax(_syntax, _action_factory);
+// External entry point for object registration
+extern "C" void
+FalconApp__registerAll(Factory & factory, ActionFactory & action_factory, Syntax & syntax)
+{
+  FalconApp::registerAll(factory, action_factory, syntax);
+}
+
+void
+FalconApp::registerAll(Factory & factory, ActionFactory & action_factory, Syntax & syntax)
+{
+  Registry::registerObjectsTo(factory, {"FalconApp"});
+  Registry::registerActionsTo(action_factory, {"FalconApp"});
+  ModulesApp::registerAll(factory, action_factory, syntax);
 }
 
 
@@ -63,21 +72,3 @@ FalconApp::registerApps()
 {
   registerApp(FalconApp);
 }
-
-
-/*******************************************************************************
-Routine: registerObjects
-*******************************************************************************/
-void
-FalconApp::registerObjects(Factory & factory)
-{
-  Registry::registerObjectsTo(factory, {"FalconApp"});
-}
-
-
-/*******************************************************************************
-Routine: registerApps
-*******************************************************************************/
-void
-FalconApp::associateSyntax(Syntax & /*syntax*/, ActionFactory & /*action_factory*/)
-{}

--- a/src/kernels/PTEnergyResidual.C
+++ b/src/kernels/PTEnergyResidual.C
@@ -52,7 +52,14 @@ PTEnergyResidual::PTEnergyResidual(const InputParameters & parameters):
   _u_dot(dot()),
   _du_dot_du(dotDu()),
   _pres_var(_has_coupled_pres ? coupled("coupled_pressure") : zero)
-{}
+{
+  // In case this is the only Kernel present in a given simulation, it
+  // is responsible for telling the FEProblem that it needs
+  // u_dot. Technically any Kernel which uses u_dot should do this
+  // now, but often it isn't needed because it is already handled by
+  // the TimeIntegrator constructor.
+  _fe_problem.setUDotRequested(true);
+}
 
 
 /*******************************************************************************

--- a/src/kernels/PTEnergyResidual.C
+++ b/src/kernels/PTEnergyResidual.C
@@ -49,6 +49,8 @@ PTEnergyResidual::PTEnergyResidual(const InputParameters & parameters):
   _tau2(getMaterialProperty<Real>("supg_tau2")),
   _wdmfx(getMaterialProperty<RealGradient>("darcy_mass_flux_water")),
   _evelo(getMaterialProperty<RealGradient>("energy_convective_velocity")),
+  _u_dot(dot()),
+  _du_dot_du(dotDu()),
   _pres_var(_has_coupled_pres ? coupled("coupled_pressure") : zero)
 {}
 

--- a/src/kernels/PTEnergyResidual.C
+++ b/src/kernels/PTEnergyResidual.C
@@ -49,16 +49,10 @@ PTEnergyResidual::PTEnergyResidual(const InputParameters & parameters):
   _tau2(getMaterialProperty<Real>("supg_tau2")),
   _wdmfx(getMaterialProperty<RealGradient>("darcy_mass_flux_water")),
   _evelo(getMaterialProperty<RealGradient>("energy_convective_velocity")),
-  _u_dot(dot()),
-  _du_dot_du(dotDu()),
+  _u_dot(_is_transient ? dot() : _zero),
+  _du_dot_du(_is_transient ? dotDu() : _zero),
   _pres_var(_has_coupled_pres ? coupled("coupled_pressure") : zero)
 {
-  // In case this is the only Kernel present in a given simulation, it
-  // is responsible for telling the FEProblem that it needs
-  // u_dot. Technically any Kernel which uses u_dot should do this
-  // now, but often it isn't needed because it is already handled by
-  // the TimeIntegrator constructor.
-  _fe_problem.setUDotRequested(true);
 }
 
 

--- a/src/materials/PTGeothermal.C
+++ b/src/materials/PTGeothermal.C
@@ -256,7 +256,7 @@ PTGeothermal::PTGeothermal(const InputParameters & parameters):
   // ============================
   // stateful material properties
   // ============================
-  _wrho_old(declarePropertyOld<Real>("density_water"))
+  _wrho_old(getMaterialPropertyOld<Real>("density_water"))
 {}
 
 /*******************************************************************************

--- a/tests/PT_H_SideFluxAverage/inp.i
+++ b/tests/PT_H_SideFluxAverage/inp.i
@@ -135,7 +135,6 @@
   [../]
   [./console]
     type = Console
-    perf_log = false
     output_linear = true
     output_nonlinear = true
   [../]

--- a/tests/PT_H_SideFluxIntegral/inp.i
+++ b/tests/PT_H_SideFluxIntegral/inp.i
@@ -135,7 +135,6 @@
   [../]
   [./console]
     type = Console
-    perf_log = false
     output_linear = true
     output_nonlinear = true
   [../]

--- a/tests/PT_H_gravity/inp.i
+++ b/tests/PT_H_gravity/inp.i
@@ -111,7 +111,6 @@
   exodus         = true
   [./Console]
     type = Console
-    perf_log = false
     output_linear = true
     output_nonlinear = true
   [../]

--- a/tests/PT_H_permeability_function/test1.i
+++ b/tests/PT_H_permeability_function/test1.i
@@ -149,7 +149,6 @@
   [../]
   [./console]
     type = Console
-    perf_log = false
     output_linear = true
     output_nonlinear = true
   [../]

--- a/tests/PT_H_permeability_function/test2.i
+++ b/tests/PT_H_permeability_function/test2.i
@@ -146,7 +146,6 @@
   [../]
   [./console]
     type = Console
-    perf_log = false
     output_linear = true
     output_nonlinear = true
   [../]

--- a/tests/PT_H_stochastic_permeability/inp.i
+++ b/tests/PT_H_stochastic_permeability/inp.i
@@ -131,7 +131,6 @@
   [../]
   [./console]
     type = Console
-    perf_log = false
     output_linear = true
     output_nonlinear = true
   [../]

--- a/tests/PT_TH_SGW2016_Reference_Case/inp3d_ini.i
+++ b/tests/PT_TH_SGW2016_Reference_Case/inp3d_ini.i
@@ -149,7 +149,6 @@
   [../]
   [./console]
     type = Console
-    perf_log = false
     output_linear = true
     output_nonlinear = true
   [../]

--- a/tests/PT_TH_SGW2016_Reference_Case/inp3d_run.i
+++ b/tests/PT_TH_SGW2016_Reference_Case/inp3d_run.i
@@ -221,7 +221,6 @@
   [../]
   [./CONSOLE]
     type = Console
-    perf_log = false
     output_linear = true
     output_nonlinear = true
     execute_postprocessors_on = 'none'

--- a/tests/PT_TH_elder/step1.i
+++ b/tests/PT_TH_elder/step1.i
@@ -80,7 +80,6 @@
   exodus         = true
   [./console]
     type = Console
-    perf_log = false
     output_linear = true
     output_nonlinear = true
   [../]

--- a/tests/PT_TH_elder/step2_comp.i
+++ b/tests/PT_TH_elder/step2_comp.i
@@ -165,7 +165,6 @@
   exodus         = true
   [./console]
     type = Console
-    perf_log = false
     output_linear = true
     output_nonlinear = true
   [../]

--- a/tests/PT_TH_elder/step2_wseos.i
+++ b/tests/PT_TH_elder/step2_wseos.i
@@ -165,7 +165,6 @@
   exodus         = true
   [./console]
     type = Console
-    perf_log = false
     output_linear = true
     output_nonlinear = true
   [../]

--- a/tests/PT_T_SideProductionIntegral/inp.i
+++ b/tests/PT_T_SideProductionIntegral/inp.i
@@ -96,7 +96,6 @@
   exodus         = true
   [./Console]
     type = Console
-    perf_log = false
     output_linear = true
     output_nonlinear = true
   [../]

--- a/tests/PT_T_conduction/inp.i
+++ b/tests/PT_T_conduction/inp.i
@@ -90,7 +90,6 @@
   exodus         = true
   [./Console]
     type = Console
-    perf_log = false
     output_linear = true
     output_nonlinear = true
   [../]

--- a/tests/PT_T_convection/inp1.i
+++ b/tests/PT_T_convection/inp1.i
@@ -106,7 +106,6 @@
   exodus         = true
   [./Console]
     type = Console
-    perf_log = false
     output_linear = true
     output_nonlinear = true
   [../]

--- a/tests/PT_T_convection/inp1_gaussian.i
+++ b/tests/PT_T_convection/inp1_gaussian.i
@@ -104,7 +104,6 @@
   exodus         = true
   [./Console]
     type = Console
-    perf_log = false
     output_linear = true
     output_nonlinear = true
   [../]

--- a/tests/PT_T_convection/inp2.i
+++ b/tests/PT_T_convection/inp2.i
@@ -106,7 +106,6 @@
   exodus         = true
   [./Console]
     type = Console
-    perf_log = false
     output_linear = true
     output_nonlinear = true
   [../]

--- a/tests/PT_T_convection/inp2_gaussian.i
+++ b/tests/PT_T_convection/inp2_gaussian.i
@@ -104,7 +104,6 @@
   exodus         = true
   [./Console]
     type = Console
-    perf_log = false
     output_linear = true
     output_nonlinear = true
   [../]

--- a/tests/PT_T_convection/inp3.i
+++ b/tests/PT_T_convection/inp3.i
@@ -112,7 +112,6 @@
   exodus         = true
   [./Console]
     type = Console
-    perf_log = false
     output_linear = true
     output_nonlinear = true
   [../]

--- a/tests/THM_injection/thm_steady.i
+++ b/tests/THM_injection/thm_steady.i
@@ -495,7 +495,6 @@
   exodus         = true
   [./console]
     type = Console
-    perf_log = false
     output_linear = true
     output_nonlinear = true
   [../]

--- a/tests/THM_injection/thm_transient.i
+++ b/tests/THM_injection/thm_transient.i
@@ -576,7 +576,6 @@
   exodus         = true
   [./console]
     type = Console
-    perf_log = false
     output_linear = true
     output_nonlinear = true
   [../]


### PR DESCRIPTION
Refs idaholab/moose#12185.

Also fix several other easy/deprecated things while we are at it.
