### PR TITLE
Remove unused parameters

### DIFF
--- a/examples/fixedStressMultiApp/mandel_master.i
+++ b/examples/fixedStressMultiApp/mandel_master.i
@@ -157,8 +157,6 @@
 
   [vol_strain]
     type = PorousFlowEffectiveFluidPressure
-    consistent_with_displaced_mesh = false
-    displacements = 'disp_x disp_y disp_z'
     PorousFlowDictator = dictator
   []
   [ppss]

--- a/test/tests/PT_H_fluxBC/inp.i
+++ b/test/tests/PT_H_fluxBC/inp.i
@@ -90,7 +90,6 @@
 ############################################################
 [Outputs]
   file_base      = out
-  output_initial = true
   interval       = 1
   exodus         = true
   [./Console]

--- a/test/tests/PT_H_freeBC/inp.i
+++ b/test/tests/PT_H_freeBC/inp.i
@@ -89,7 +89,6 @@
 ############################################################
 [Outputs]
   file_base      = out
-  output_initial = true
   interval       = 1
   exodus         = true
   [./Console]


### PR DESCRIPTION
MOOSE is changing the default behavior of unused parameters from a warning to an error. Since there are tests in this Moose app with unused parameters, this app's tests must have there unused parameters removed. More info in the Issue.

Closes #93 