### PR TITLE
Changing JSONDiff in tests to upcoming SchemaDiff

### DIFF
--- a/test/tests/reporters/closest_elems_to_line/tests
+++ b/test/tests/reporters/closest_elems_to_line/tests
@@ -1,10 +1,10 @@
 [Tests]
   issues='97'
   [./constant_projection]
-    type = 'JSONDiff'
+    type = 'SchemaDiff'
     input    = 'constant_line_projection.i'
-    jsondiff = 'constant_line_projection_out.json'
-    skip_keys = 'type'
+    schemadiff = 'constant_line_projection_out.json'
+    ignored_items = 'type'
     requirement = 'The system shall be able to report the coordinates of all the locations where a line intersects an element'
   [../]
 []

--- a/test/tests/reporters/closest_elems_to_line_with_values/tests
+++ b/test/tests/reporters/closest_elems_to_line_with_values/tests
@@ -1,10 +1,10 @@
 [Tests]
   issues='97'
   [./dfn]
-    type = 'JSONDiff'
+    type = 'SchemaDiff'
     input    = 'dfn_test.i'
-    jsondiff = 'dfn_test_out.json'
-    skip_keys = 'type'
+    schemadiff = 'dfn_test_out.json'
+    ignored_items = 'type'
     requirement = 'The system shall be able to report the coordinates of all the locations where a line intersects an element and append a value onto each element in a realistic DFN'
   [../]
 []

--- a/test/tests/reporters/closest_node_data/tests
+++ b/test/tests/reporters/closest_node_data/tests
@@ -1,9 +1,9 @@
 [Tests]
     [test_nodal_aux_var_value]
-      type = 'JSONDiff'
+      type = 'SchemaDiff'
       input = 'nodal_var_value.i'
-      jsondiff = 'nodal_var_value_out.json'
-      skip_keys = 'type'
+      schemadiff = 'nodal_var_value_out.json'
+      ignored_items = 'type'
       requirement = 'The reporter shall output the nodal data from the closest node to the input coordiantes.'
       issues = '#2281'
     []

--- a/test/tests/reporters/closest_node_projector/tests
+++ b/test/tests/reporters/closest_node_projector/tests
@@ -1,10 +1,10 @@
 [Tests]
   issues='48'
   [./constant_projection]
-    type = 'JSONDiff'
+    type = 'SchemaDiff'
     input    = 'constant_projection.i'
-    jsondiff = 'constant_projection_out.json'
-    skip_keys = 'type'
+    schemadiff = 'constant_projection_out.json'
+    ignored_items = 'type'
     requirement = 'The system shall be able to report the coordinates of the closest node and hold a value for that node that can be consumed other objects'
   [../]
 []


### PR DESCRIPTION
The old JSON and XML differs are being changed to a universal schema differ with more functionality. That means that falcon will fail its tests until their tests are changed. This shouldn't be merged in immediately, coordinating these changes will be important.

Closes #110 

SchemaDiff PR: https://github.com/idaholab/moose/pull/21791