### PR TITLE
Fixed usage of deprecated Picard parameters

### DIFF
--- a/examples/fixedStressMultiApp/mandel_master.i
+++ b/examples/fixedStressMultiApp/mandel_master.i
@@ -178,9 +178,9 @@
 
   #fixed_point_algorithm = 'secant'
 
-  accept_on_max_picard_iteration = true
-  picard_max_its = 2
-  picard_rel_tol = 1e-20
+  accept_on_max_fixed_point_iteration = true
+  fixed_point_max_its = 2
+  fixed_point_rel_tol = 1e-20
 
   relaxation_factor = 0.5
   relaxed_variables = 'disp_x disp_y disp_z'


### PR DESCRIPTION
This fix is for https://github.com/idaholab/moose/pull/30789.