### PR TITLE
Update for MetaPhysicl 2.0

### DIFF
--- a/src/auxkernels/StochasticFieldAux.C
+++ b/src/auxkernels/StochasticFieldAux.C
@@ -37,5 +37,5 @@ StochasticFieldAux::StochasticFieldAux(const InputParameters & parameters)
 Real
 StochasticFieldAux::computeValue()
 {
-  return _stoch_field.value(_current_elem->centroid());
+  return _stoch_field.value(_current_elem->vertex_average());
 }

--- a/src/functions/FalconPiecewiseBilinear.C
+++ b/src/functions/FalconPiecewiseBilinear.C
@@ -130,9 +130,10 @@ FalconPiecewiseBilinear::valueInternal(T t, const P & p) const
   T retVal = 0.0;
   if (_yaxisValid && _xaxisValid && _radial)
   {
+    using std::sqrt;
     const auto rx = p(_xaxis) * p(_xaxis);
     const auto ry = p(_yaxis) * p(_yaxis);
-    const auto r = std::sqrt(rx + ry);
+    const auto r = sqrt(rx + ry);
     retVal = _bilinear_interp->sample(r, t);
   }
   else if (_axisValid)

--- a/src/materials/ADWallHeatTransferCoefficient3EqnMaterial.C
+++ b/src/materials/ADWallHeatTransferCoefficient3EqnMaterial.C
@@ -53,33 +53,43 @@ static
 ADReal
 naturalConvectionLiquid(ADReal Gr, ADReal Pr)
 {
+  using std::cbrt;
+  using std::max;
+  using std::pow;
   // Eq. 6-20
-  ADReal turb = 0.1 * std::cbrt(Gr * Pr);
+  ADReal turb = 0.1 * cbrt(Gr * Pr);
   // Eq. 6-16
-  ADReal lam = 0.59 * std::pow(Gr * Pr, 0.25);
+  ADReal lam = 0.59 * pow(Gr * Pr, 0.25);
   // Eq. 6-14
-  return std::max(turb, lam);
+  return max(turb, lam);
 }
 
 static
 ADReal
 Gnielinski(ADReal Pr, ADReal Re)
 {
+  using std::log;
+  using std::max;
+  using std::pow;
   // see TRACE manual p. 255
-  Pr = std::max(0.5, Pr);
+  Pr = max(0.5, Pr);
   // see TRACE manual p. 255
-  Re = std::max(1000., Re);
+  Re = max(1000., Re);
   // Eq. 6-10
-  ADReal f = std::pow(1.58 * std::log(Re) - 3.28, -2);
+  ADReal f = pow(1.58 * log(Re) - 3.28, -2);
   ADReal f2 = f * 0.5;
   // Eq. 6-9
-  return (f2 * (Re - 1000) * Pr) / (1 + 12.7 * std::pow(f2, 0.5) * (std::pow(Pr, 2. / 3.) - 1));
+  return (f2 * (Re - 1000) * Pr) /
+         (1 + 12.7 * pow(f2, 0.5) * (pow(Pr, 2. / 3.) - 1));
 }
 
 void
 ADWallHeatTransferCoefficient3EqnMaterial::computeQpProperties()
 {
-  ADReal Re = std::max(1.0, _Re[_qp]);
+  using std::abs;
+  using std::max;
+  using std::pow;
+  ADReal Re = max(1.0, _Re[_qp]);
 
   ADReal beta = _fp.beta_from_p_T(_p[_qp], _T[_qp]);
   // Note that Equation (6-19) in the TRACE V5.0 theory manual gives the film
@@ -92,9 +102,11 @@ ADWallHeatTransferCoefficient3EqnMaterial::computeQpProperties()
   //   rho_film = rho + 0.5 * drho/dT * (T_wall - T)
   const ADReal drho_dT = -beta * _rho[_qp]; // Using the relation: beta = -drho/dT / rho
   const ADReal rho_film = _rho[_qp] + 0.5 * drho_dT * (_T_wall[_qp] - _T[_qp]);
-  ADReal dT = std::abs(_T_wall[_qp] - _T[_qp]);
+  ADReal dT = abs(_T_wall[_qp] - _T[_qp]);
   // Eq. 6-17
-  ADReal Gr = std::max(THM::Grashof(beta, dT, _D_h[_qp], rho_film, _mu[_qp], _gravity_magnitude), 1.e-20);
+  ADReal Gr = max(
+      THM::Grashof(beta, dT, _D_h[_qp], rho_film, _mu[_qp], _gravity_magnitude),
+      1.e-20);
   const ADReal rho_w = _fp.rho_from_p_T(_p[_qp], _T_wall[_qp]);
   const ADReal e_w = _fp.e_from_p_rho(_p[_qp], rho_w);
   ADReal Pr_w = THM::Prandtl(_fp.cp_from_v_e(1 / rho_w, e_w),
@@ -103,12 +115,12 @@ ADWallHeatTransferCoefficient3EqnMaterial::computeQpProperties()
 
   // turbulent flow (eq 6-12)
   ADReal Pr_ratio = _Pr[_qp] / Pr_w;
-  ADReal Nu_turb = Gnielinski(_Pr[_qp], Re) * std::pow(Pr_ratio, 0.11);
+  ADReal Nu_turb = Gnielinski(_Pr[_qp], Re) * pow(Pr_ratio, 0.11);
 
-  ADReal Nu_fc = std::max(Nu_lam_const, Nu_turb);
+  ADReal Nu_fc = max(Nu_lam_const, Nu_turb);
 
   ADReal Nu_nc = naturalConvectionLiquid(Gr, _Pr[_qp]);
-  ADReal Nu = std::max(Nu_fc, Nu_nc);
+  ADReal Nu = max(Nu_fc, Nu_nc);
 
   _Hw[_qp] = THM::wallHeatTransferCoefficient(Nu, _k[_qp], _D_h[_qp]);
 }


### PR DESCRIPTION
Refs incoming MetaPhysicL 2.0 changes in
[idaholab/moose#31906](https://github.com/idaholab/moose/pull/31906). MetaPhysicL used to put its overloads in the std namespace which is not standard compliant. However, this is fixed in MetaPhysicL 2.0. This patch will allow both backward and forward compatibility with MetaPhysicL 1 and 2 respectively